### PR TITLE
Fixed kubeconfig template structure to make it compatible with `kubectl`

### DIFF
--- a/internal/provider/cloudspace_data_source.go
+++ b/internal/provider/cloudspace_data_source.go
@@ -128,25 +128,25 @@ type KubeconfigVars struct {
 
 const kubeconfigTemplate = `apiVersion: v1
 clusters:
-- cluster:
-	insecure-skip-tls-verify: {{.InsecureSkipTLSVerify}}
-	server: >-
-	https://{{.Server}}/
-name: {{.Cluster}}
+  - cluster:
+      insecure-skip-tls-verify: {{.InsecureSkipTLSVerify}}
+      server: >-
+        https://{{.Server}}/
+    name: {{.Cluster}}
 contexts:
-- context:
-	cluster: {{.Cluster}}
-	namespace: default
-	user: {{.User}}
-name: {{.OrgName}}-{{.Cluster}}
+  - context:
+      cluster: {{.Cluster}}
+      namespace: default
+      user: {{.User}}
+    name: {{.OrgName}}-{{.Cluster}}
 current-context: {{.OrgName}}-{{.Cluster}}
 kind: Config
 preferences: {}
 users:
-- name: {{.User}}
-user:
-	token: >-
-	{{.Token}}
+  - name: {{.User}}
+    user:
+      token: >-
+        {{.Token}}
 `
 
 func createKubeconfig(kubeconfigVars KubeconfigVars) (string, error) {


### PR DESCRIPTION
This fix lets users generate the kubeconfigs without going to https://spot.rackspace.com/ui/cloudspaces/CLOUDSPACE_NAME/overview and clicking the download kubeconfig.
See issue https://github.com/rackerlabs/spot-roadmap/issues/13

Example usage:
```hcl
data "spot_cloudspace" "cloudspace" {
  for_each = spot_cloudspace.cloudspace
  id = each.value.id
}

resource "local_sensitive_file" "kubeconfig" {
  for_each = data.spot_cloudspace.cloudspace
  content  = each.value.kubeconfig
  filename = pathexpand("../kubeconfigs/${each.key}-kubeconfig.yaml")
}

resource "local_sensitive_file" "home_kubeconfig" {
  for_each = data.spot_cloudspace.cloudspace
  content  = each.value.kubeconfig
  filename = pathexpand("~/.kube/${each.key}-kubeconfig.yaml")
}
```

There was a tiny issue with the indentation that caused incompatibility with `kubectl`.

Unfortunately I wasn't able to thoroughly test this fix, due to not having access to github.com/RSS-Engineering/ngpc-cp .