### PR TITLE
Node-metadata

### DIFF
--- a/docs/data-sources/spotnodepool.md
+++ b/docs/data-sources/spotnodepool.md
@@ -17,8 +17,11 @@ description: |-
 
 ### Optional
 
+- `annotations` (Map of String) Annotations to be applied to the nodes of the node pool
 - `id` (String, Deprecated) ID of the spotnodepool, same as name.
+- `labels` (Map of String) Labels to be applied to the nodes of the node pool
 - `name` (String) Name of the spotnodepool
+- `taints` (Attributes List) Kubernetes taints to be applied to the nodes of the node pool (see [below for nested schema](#nestedatt--taints))
 
 ### Read-Only
 
@@ -29,6 +32,19 @@ description: |-
 - `desired_server_count` (Number) The desired number of servers in the node pool.
 - `server_class` (String) The class of servers used for the node pool.
 - `won_count` (Number) Number of won bids.
+
+<a id="nestedatt--taints"></a>
+### Nested Schema for `taints`
+
+Required:
+
+- `effect` (String) The taint effect (NoSchedule, PreferNoSchedule, or NoExecute)
+- `key` (String) The taint key to be applied
+
+Optional:
+
+- `value` (String) The taint value
+
 
 <a id="nestedatt--autoscaling"></a>
 ### Nested Schema for `autoscaling`

--- a/docs/resources/ondemandnodepool.md
+++ b/docs/resources/ondemandnodepool.md
@@ -30,12 +30,30 @@ resource "spot_ondemandnodepool" "example" {
 - `desired_server_count` (Number) The desired number of servers in the node pool.
 - `server_class` (String) The server class to be used for the node pool can be obtained from the serverclasses data source.
 
+### Optional
+
+- `annotations` (Map of String) Annotations to be applied to the nodes of the node pool
+- `labels` (Map of String) Labels to be applied to the nodes of the node pool
+- `taints` (Attributes List) Kubernetes taints to be applied to the nodes of the node pool (see [below for nested schema](#nestedatt--taints))
+
 ### Read-Only
 
 - `last_updated` (String) The last time the ondemandnodepool was updated.
 - `name` (String) The name of the ondemandnodepool.
 - `reserved_count` (Number) Number of reserved on-demand nodes.
 - `reserved_status` (String) Status of the ondemandnodepool.
+
+<a id="nestedatt--taints"></a>
+### Nested Schema for `taints`
+
+Required:
+
+- `effect` (String) The taint effect (NoSchedule, PreferNoSchedule, or NoExecute)
+- `key` (String) The taint key to be applied
+
+Optional:
+
+- `value` (String) The taint value
 
 ## Import
 

--- a/docs/resources/spotnodepool.md
+++ b/docs/resources/spotnodepool.md
@@ -36,8 +36,11 @@ resource "spot_spotnodepool" "example" {
 
 ### Optional
 
+- `annotations` (Map of String) Annotations to be applied to the nodes of the node pool
 - `autoscaling` (Attributes) Scales the nodes in a cluster based on usage. This block should be omitted to disable autoscaling. (see [below for nested schema](#nestedatt--autoscaling))
 - `desired_server_count` (Number) The desired number of servers in the node pool. Should be removed if autoscaling is enabled.
+- `labels` (Map of String) Labels to be applied to the nodes of the node pool
+- `taints` (Attributes List) Kubernetes taints to be applied to the nodes of the node pool (see [below for nested schema](#nestedatt--taints))
 
 ### Read-Only
 
@@ -54,6 +57,19 @@ Optional:
 
 - `max_nodes` (Number) The maximum number of nodes in the node pool.
 - `min_nodes` (Number) The minimum number of nodes in the node pool.
+
+
+<a id="nestedatt--taints"></a>
+### Nested Schema for `taints`
+
+Required:
+
+- `effect` (String) The taint effect (NoSchedule, PreferNoSchedule, or NoExecute)
+- `key` (String) The taint key to be applied
+
+Optional:
+
+- `value` (String) The taint value
 
 ## Import
 

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.23.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	golang.org/x/oauth2 v0.21.0
+	k8s.io/api v0.30.3
 	k8s.io/apimachinery v0.30.3
 )
 
@@ -116,7 +117,6 @@ require (
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.30.3 // indirect
 	k8s.io/apiextensions-apiserver v0.30.3 // indirect
 	k8s.io/client-go v0.30.3 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect

--- a/internal/provider/datasource_ondemandnodepool/ondemandnodepool_data_source_gen.go
+++ b/internal/provider/datasource_ondemandnodepool/ondemandnodepool_data_source_gen.go
@@ -4,10 +4,16 @@ package datasource_ondemandnodepool
 
 import (
 	"context"
+	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"regexp"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 )
@@ -15,6 +21,12 @@ import (
 func OndemandnodepoolDataSourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
 		Attributes: map[string]schema.Attribute{
+			"annotations": schema.MapAttribute{
+				ElementType:         types.StringType,
+				Optional:            true,
+				Description:         "Annotations to be applied to the nodes of the node pool",
+				MarkdownDescription: "Annotations to be applied to the nodes of the node pool",
+			},
 			"cloudspace_name": schema.StringAttribute{
 				Computed:            true,
 				Description:         "The name of the cloudspace",
@@ -24,6 +36,12 @@ func OndemandnodepoolDataSourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "The desired number of servers in the node pool.",
 				MarkdownDescription: "The desired number of servers in the node pool.",
+			},
+			"labels": schema.MapAttribute{
+				ElementType:         types.StringType,
+				Optional:            true,
+				Description:         "Labels to be applied to the nodes of the node pool",
+				MarkdownDescription: "Labels to be applied to the nodes of the node pool",
 			},
 			"name": schema.StringAttribute{
 				Optional:            true,
@@ -50,15 +68,474 @@ func OndemandnodepoolDataSourceSchema(ctx context.Context) schema.Schema {
 				Description:         "The class of servers used for the node pool",
 				MarkdownDescription: "The class of servers used for the node pool",
 			},
+			"taints": schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"effect": schema.StringAttribute{
+							Required:            true,
+							Description:         "The taint effect (NoSchedule, PreferNoSchedule, or NoExecute)",
+							MarkdownDescription: "The taint effect (NoSchedule, PreferNoSchedule, or NoExecute)",
+							Validators: []validator.String{
+								stringvalidator.OneOf("NoSchedule", "PreferNoSchedule", "NoExecute"),
+							},
+						},
+						"key": schema.StringAttribute{
+							Required:            true,
+							Description:         "The taint key to be applied",
+							MarkdownDescription: "The taint key to be applied",
+						},
+						"value": schema.StringAttribute{
+							Optional:            true,
+							Description:         "The taint value",
+							MarkdownDescription: "The taint value",
+						},
+					},
+					CustomType: TaintsType{
+						ObjectType: types.ObjectType{
+							AttrTypes: TaintsValue{}.AttributeTypes(ctx),
+						},
+					},
+				},
+				Optional:            true,
+				Description:         "Kubernetes taints to be applied to the nodes of the node pool",
+				MarkdownDescription: "Kubernetes taints to be applied to the nodes of the node pool",
+			},
 		},
 	}
 }
 
 type OndemandnodepoolModel struct {
+	Annotations        types.Map    `tfsdk:"annotations"`
 	CloudspaceName     types.String `tfsdk:"cloudspace_name"`
 	DesiredServerCount types.Int64  `tfsdk:"desired_server_count"`
+	Labels             types.Map    `tfsdk:"labels"`
 	Name               types.String `tfsdk:"name"`
 	ReservedCount      types.Int64  `tfsdk:"reserved_count"`
 	ReservedStatus     types.String `tfsdk:"reserved_status"`
 	ServerClass        types.String `tfsdk:"server_class"`
+	Taints             types.List   `tfsdk:"taints"`
+}
+
+var _ basetypes.ObjectTypable = TaintsType{}
+
+type TaintsType struct {
+	basetypes.ObjectType
+}
+
+func (t TaintsType) Equal(o attr.Type) bool {
+	other, ok := o.(TaintsType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t TaintsType) String() string {
+	return "TaintsType"
+}
+
+func (t TaintsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributes := in.Attributes()
+
+	effectAttribute, ok := attributes["effect"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`effect is missing from object`)
+
+		return nil, diags
+	}
+
+	effectVal, ok := effectAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`effect expected to be basetypes.StringValue, was: %T`, effectAttribute))
+	}
+
+	keyAttribute, ok := attributes["key"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`key is missing from object`)
+
+		return nil, diags
+	}
+
+	keyVal, ok := keyAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`key expected to be basetypes.StringValue, was: %T`, keyAttribute))
+	}
+
+	valueAttribute, ok := attributes["value"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`value is missing from object`)
+
+		return nil, diags
+	}
+
+	valueVal, ok := valueAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`value expected to be basetypes.StringValue, was: %T`, valueAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return TaintsValue{
+		Effect: effectVal,
+		Key:    keyVal,
+		Value:  valueVal,
+		state:  attr.ValueStateKnown,
+	}, diags
+}
+
+func NewTaintsValueNull() TaintsValue {
+	return TaintsValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewTaintsValueUnknown() TaintsValue {
+	return TaintsValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewTaintsValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (TaintsValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing TaintsValue Attribute Value",
+				"While creating a TaintsValue value, a missing attribute value was detected. "+
+					"A TaintsValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("TaintsValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid TaintsValue Attribute Type",
+				"While creating a TaintsValue value, an invalid attribute value was detected. "+
+					"A TaintsValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("TaintsValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("TaintsValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra TaintsValue Attribute Value",
+				"While creating a TaintsValue value, an extra attribute value was detected. "+
+					"A TaintsValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra TaintsValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewTaintsValueUnknown(), diags
+	}
+
+	effectAttribute, ok := attributes["effect"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`effect is missing from object`)
+
+		return NewTaintsValueUnknown(), diags
+	}
+
+	effectVal, ok := effectAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`effect expected to be basetypes.StringValue, was: %T`, effectAttribute))
+	}
+
+	keyAttribute, ok := attributes["key"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`key is missing from object`)
+
+		return NewTaintsValueUnknown(), diags
+	}
+
+	keyVal, ok := keyAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`key expected to be basetypes.StringValue, was: %T`, keyAttribute))
+	}
+
+	valueAttribute, ok := attributes["value"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`value is missing from object`)
+
+		return NewTaintsValueUnknown(), diags
+	}
+
+	valueVal, ok := valueAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`value expected to be basetypes.StringValue, was: %T`, valueAttribute))
+	}
+
+	if diags.HasError() {
+		return NewTaintsValueUnknown(), diags
+	}
+
+	return TaintsValue{
+		Effect: effectVal,
+		Key:    keyVal,
+		Value:  valueVal,
+		state:  attr.ValueStateKnown,
+	}, diags
+}
+
+func NewTaintsValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) TaintsValue {
+	object, diags := NewTaintsValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewTaintsValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t TaintsType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewTaintsValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewTaintsValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewTaintsValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewTaintsValueMust(TaintsValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t TaintsType) ValueType(ctx context.Context) attr.Value {
+	return TaintsValue{}
+}
+
+var _ basetypes.ObjectValuable = TaintsValue{}
+
+type TaintsValue struct {
+	Effect basetypes.StringValue `tfsdk:"effect"`
+	Key    basetypes.StringValue `tfsdk:"key"`
+	Value  basetypes.StringValue `tfsdk:"value"`
+	state  attr.ValueState
+}
+
+func (v TaintsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 3)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["effect"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["key"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["value"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 3)
+
+		val, err = v.Effect.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["effect"] = val
+
+		val, err = v.Key.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["key"] = val
+
+		val, err = v.Value.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["value"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v TaintsValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v TaintsValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v TaintsValue) String() string {
+	return "TaintsValue"
+}
+
+func (v TaintsValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	objVal, diags := types.ObjectValue(
+		map[string]attr.Type{
+			"effect": basetypes.StringType{},
+			"key":    basetypes.StringType{},
+			"value":  basetypes.StringType{},
+		},
+		map[string]attr.Value{
+			"effect": v.Effect,
+			"key":    v.Key,
+			"value":  v.Value,
+		})
+
+	return objVal, diags
+}
+
+func (v TaintsValue) Equal(o attr.Value) bool {
+	other, ok := o.(TaintsValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.Effect.Equal(other.Effect) {
+		return false
+	}
+
+	if !v.Key.Equal(other.Key) {
+		return false
+	}
+
+	if !v.Value.Equal(other.Value) {
+		return false
+	}
+
+	return true
+}
+
+func (v TaintsValue) Type(ctx context.Context) attr.Type {
+	return TaintsType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v TaintsValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"effect": basetypes.StringType{},
+		"key":    basetypes.StringType{},
+		"value":  basetypes.StringType{},
+	}
 }

--- a/internal/provider/datasource_spotnodepool/spotnodepool_data_source_gen.go
+++ b/internal/provider/datasource_spotnodepool/spotnodepool_data_source_gen.go
@@ -22,6 +22,12 @@ import (
 func SpotnodepoolDataSourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
 		Attributes: map[string]schema.Attribute{
+			"annotations": schema.MapAttribute{
+				ElementType:         types.StringType,
+				Optional:            true,
+				Description:         "Annotations to be applied to the nodes of the node pool",
+				MarkdownDescription: "Annotations to be applied to the nodes of the node pool",
+			},
 			"autoscaling": schema.SingleNestedAttribute{
 				Attributes: map[string]schema.Attribute{
 					"max_nodes": schema.Int64Attribute{
@@ -69,6 +75,12 @@ func SpotnodepoolDataSourceSchema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "ID of the spotnodepool, same as name.",
 				DeprecationMessage:  "Use the name attribute instead",
 			},
+			"labels": schema.MapAttribute{
+				ElementType:         types.StringType,
+				Optional:            true,
+				Description:         "Labels to be applied to the nodes of the node pool",
+				MarkdownDescription: "Labels to be applied to the nodes of the node pool",
+			},
 			"name": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
@@ -85,6 +97,38 @@ func SpotnodepoolDataSourceSchema(ctx context.Context) schema.Schema {
 				Description:         "The class of servers used for the node pool.",
 				MarkdownDescription: "The class of servers used for the node pool.",
 			},
+			"taints": schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"effect": schema.StringAttribute{
+							Required:            true,
+							Description:         "The taint effect (NoSchedule, PreferNoSchedule, or NoExecute)",
+							MarkdownDescription: "The taint effect (NoSchedule, PreferNoSchedule, or NoExecute)",
+							Validators: []validator.String{
+								stringvalidator.OneOf("NoSchedule", "PreferNoSchedule", "NoExecute"),
+							},
+						},
+						"key": schema.StringAttribute{
+							Required:            true,
+							Description:         "The taint key to be applied",
+							MarkdownDescription: "The taint key to be applied",
+						},
+						"value": schema.StringAttribute{
+							Optional:            true,
+							Description:         "The taint value",
+							MarkdownDescription: "The taint value",
+						},
+					},
+					CustomType: TaintsType{
+						ObjectType: types.ObjectType{
+							AttrTypes: TaintsValue{}.AttributeTypes(ctx),
+						},
+					},
+				},
+				Optional:            true,
+				Description:         "Kubernetes taints to be applied to the nodes of the node pool",
+				MarkdownDescription: "Kubernetes taints to be applied to the nodes of the node pool",
+			},
 			"won_count": schema.Int64Attribute{
 				Computed:            true,
 				Description:         "Number of won bids.",
@@ -95,14 +139,17 @@ func SpotnodepoolDataSourceSchema(ctx context.Context) schema.Schema {
 }
 
 type SpotnodepoolModel struct {
+	Annotations        types.Map        `tfsdk:"annotations"`
 	Autoscaling        AutoscalingValue `tfsdk:"autoscaling"`
 	BidPrice           types.Float64    `tfsdk:"bid_price"`
 	BidStatus          types.String     `tfsdk:"bid_status"`
 	CloudspaceName     types.String     `tfsdk:"cloudspace_name"`
 	DesiredServerCount types.Int64      `tfsdk:"desired_server_count"`
 	Id                 types.String     `tfsdk:"id"`
+	Labels             types.Map        `tfsdk:"labels"`
 	Name               types.String     `tfsdk:"name"`
 	ServerClass        types.String     `tfsdk:"server_class"`
+	Taints             types.List       `tfsdk:"taints"`
 	WonCount           types.Int64      `tfsdk:"won_count"`
 }
 
@@ -472,5 +519,429 @@ func (v AutoscalingValue) AttributeTypes(ctx context.Context) map[string]attr.Ty
 	return map[string]attr.Type{
 		"max_nodes": basetypes.Int64Type{},
 		"min_nodes": basetypes.Int64Type{},
+	}
+}
+
+var _ basetypes.ObjectTypable = TaintsType{}
+
+type TaintsType struct {
+	basetypes.ObjectType
+}
+
+func (t TaintsType) Equal(o attr.Type) bool {
+	other, ok := o.(TaintsType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t TaintsType) String() string {
+	return "TaintsType"
+}
+
+func (t TaintsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributes := in.Attributes()
+
+	effectAttribute, ok := attributes["effect"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`effect is missing from object`)
+
+		return nil, diags
+	}
+
+	effectVal, ok := effectAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`effect expected to be basetypes.StringValue, was: %T`, effectAttribute))
+	}
+
+	keyAttribute, ok := attributes["key"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`key is missing from object`)
+
+		return nil, diags
+	}
+
+	keyVal, ok := keyAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`key expected to be basetypes.StringValue, was: %T`, keyAttribute))
+	}
+
+	valueAttribute, ok := attributes["value"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`value is missing from object`)
+
+		return nil, diags
+	}
+
+	valueVal, ok := valueAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`value expected to be basetypes.StringValue, was: %T`, valueAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return TaintsValue{
+		Effect: effectVal,
+		Key:    keyVal,
+		Value:  valueVal,
+		state:  attr.ValueStateKnown,
+	}, diags
+}
+
+func NewTaintsValueNull() TaintsValue {
+	return TaintsValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewTaintsValueUnknown() TaintsValue {
+	return TaintsValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewTaintsValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (TaintsValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing TaintsValue Attribute Value",
+				"While creating a TaintsValue value, a missing attribute value was detected. "+
+					"A TaintsValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("TaintsValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid TaintsValue Attribute Type",
+				"While creating a TaintsValue value, an invalid attribute value was detected. "+
+					"A TaintsValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("TaintsValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("TaintsValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra TaintsValue Attribute Value",
+				"While creating a TaintsValue value, an extra attribute value was detected. "+
+					"A TaintsValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra TaintsValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewTaintsValueUnknown(), diags
+	}
+
+	effectAttribute, ok := attributes["effect"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`effect is missing from object`)
+
+		return NewTaintsValueUnknown(), diags
+	}
+
+	effectVal, ok := effectAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`effect expected to be basetypes.StringValue, was: %T`, effectAttribute))
+	}
+
+	keyAttribute, ok := attributes["key"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`key is missing from object`)
+
+		return NewTaintsValueUnknown(), diags
+	}
+
+	keyVal, ok := keyAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`key expected to be basetypes.StringValue, was: %T`, keyAttribute))
+	}
+
+	valueAttribute, ok := attributes["value"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`value is missing from object`)
+
+		return NewTaintsValueUnknown(), diags
+	}
+
+	valueVal, ok := valueAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`value expected to be basetypes.StringValue, was: %T`, valueAttribute))
+	}
+
+	if diags.HasError() {
+		return NewTaintsValueUnknown(), diags
+	}
+
+	return TaintsValue{
+		Effect: effectVal,
+		Key:    keyVal,
+		Value:  valueVal,
+		state:  attr.ValueStateKnown,
+	}, diags
+}
+
+func NewTaintsValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) TaintsValue {
+	object, diags := NewTaintsValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewTaintsValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t TaintsType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewTaintsValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewTaintsValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewTaintsValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewTaintsValueMust(TaintsValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t TaintsType) ValueType(ctx context.Context) attr.Value {
+	return TaintsValue{}
+}
+
+var _ basetypes.ObjectValuable = TaintsValue{}
+
+type TaintsValue struct {
+	Effect basetypes.StringValue `tfsdk:"effect"`
+	Key    basetypes.StringValue `tfsdk:"key"`
+	Value  basetypes.StringValue `tfsdk:"value"`
+	state  attr.ValueState
+}
+
+func (v TaintsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 3)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["effect"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["key"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["value"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 3)
+
+		val, err = v.Effect.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["effect"] = val
+
+		val, err = v.Key.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["key"] = val
+
+		val, err = v.Value.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["value"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v TaintsValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v TaintsValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v TaintsValue) String() string {
+	return "TaintsValue"
+}
+
+func (v TaintsValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	objVal, diags := types.ObjectValue(
+		map[string]attr.Type{
+			"effect": basetypes.StringType{},
+			"key":    basetypes.StringType{},
+			"value":  basetypes.StringType{},
+		},
+		map[string]attr.Value{
+			"effect": v.Effect,
+			"key":    v.Key,
+			"value":  v.Value,
+		})
+
+	return objVal, diags
+}
+
+func (v TaintsValue) Equal(o attr.Value) bool {
+	other, ok := o.(TaintsValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.Effect.Equal(other.Effect) {
+		return false
+	}
+
+	if !v.Key.Equal(other.Key) {
+		return false
+	}
+
+	if !v.Value.Equal(other.Value) {
+		return false
+	}
+
+	return true
+}
+
+func (v TaintsValue) Type(ctx context.Context) attr.Type {
+	return TaintsType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v TaintsValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"effect": basetypes.StringType{},
+		"key":    basetypes.StringType{},
+		"value":  basetypes.StringType{},
 	}
 }

--- a/internal/provider/ondemandnodepool_resource.go
+++ b/internal/provider/ondemandnodepool_resource.go
@@ -226,6 +226,9 @@ func (r *ondemandnodepoolResource) Update(ctx context.Context, req resource.Upda
 	}
 
 	// Get the latest version of the resource before updating
+	// We need to get the latest version to ensure we have the most up-to-date resource version
+	// This is required for Kubernetes optimistic concurrency control, even though Terraform does its own refresh
+	// because other controllers may have modified the resource between our read and update
 	tflog.Debug(ctx, "Getting latest version of ondemandnodepool", map[string]any{"name": name})
 	latest := &ngpcv1.OnDemandNodePool{}
 	err = r.ngpcClient.Get(ctx, ktypes.NamespacedName{Name: name, Namespace: namespace}, latest)

--- a/internal/provider/resource_ondemandnodepool/ondemandnodepool_resource_gen.go
+++ b/internal/provider/resource_ondemandnodepool/ondemandnodepool_resource_gen.go
@@ -4,14 +4,20 @@ package resource_ondemandnodepool
 
 import (
 	"context"
+	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"regexp"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 )
@@ -19,6 +25,12 @@ import (
 func OndemandnodepoolResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
 		Attributes: map[string]schema.Attribute{
+			"annotations": schema.MapAttribute{
+				ElementType:         types.StringType,
+				Optional:            true,
+				Description:         "Annotations to be applied to the nodes of the node pool",
+				MarkdownDescription: "Annotations to be applied to the nodes of the node pool",
+			},
 			"cloudspace_name": schema.StringAttribute{
 				Required:            true,
 				Description:         "The name of the cloudspace.",
@@ -38,6 +50,12 @@ func OndemandnodepoolResourceSchema(ctx context.Context) schema.Schema {
 				Validators: []validator.Int64{
 					int64validator.AtLeast(1),
 				},
+			},
+			"labels": schema.MapAttribute{
+				ElementType:         types.StringType,
+				Optional:            true,
+				Description:         "Labels to be applied to the nodes of the node pool",
+				MarkdownDescription: "Labels to be applied to the nodes of the node pool",
 			},
 			"last_updated": schema.StringAttribute{
 				Computed:            true,
@@ -79,16 +97,475 @@ func OndemandnodepoolResourceSchema(ctx context.Context) schema.Schema {
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
+			"taints": schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"effect": schema.StringAttribute{
+							Required:            true,
+							Description:         "The taint effect (NoSchedule, PreferNoSchedule, or NoExecute)",
+							MarkdownDescription: "The taint effect (NoSchedule, PreferNoSchedule, or NoExecute)",
+							Validators: []validator.String{
+								stringvalidator.OneOf("NoSchedule", "PreferNoSchedule", "NoExecute"),
+							},
+						},
+						"key": schema.StringAttribute{
+							Required:            true,
+							Description:         "The taint key to be applied",
+							MarkdownDescription: "The taint key to be applied",
+						},
+						"value": schema.StringAttribute{
+							Optional:            true,
+							Description:         "The taint value",
+							MarkdownDescription: "The taint value",
+						},
+					},
+					CustomType: TaintsType{
+						ObjectType: types.ObjectType{
+							AttrTypes: TaintsValue{}.AttributeTypes(ctx),
+						},
+					},
+				},
+				Optional:            true,
+				Description:         "Kubernetes taints to be applied to the nodes of the node pool",
+				MarkdownDescription: "Kubernetes taints to be applied to the nodes of the node pool",
+			},
 		},
 	}
 }
 
 type OndemandnodepoolModel struct {
+	Annotations        types.Map    `tfsdk:"annotations"`
 	CloudspaceName     types.String `tfsdk:"cloudspace_name"`
 	DesiredServerCount types.Int64  `tfsdk:"desired_server_count"`
+	Labels             types.Map    `tfsdk:"labels"`
 	LastUpdated        types.String `tfsdk:"last_updated"`
 	Name               types.String `tfsdk:"name"`
 	ReservedCount      types.Int64  `tfsdk:"reserved_count"`
 	ReservedStatus     types.String `tfsdk:"reserved_status"`
 	ServerClass        types.String `tfsdk:"server_class"`
+	Taints             types.List   `tfsdk:"taints"`
+}
+
+var _ basetypes.ObjectTypable = TaintsType{}
+
+type TaintsType struct {
+	basetypes.ObjectType
+}
+
+func (t TaintsType) Equal(o attr.Type) bool {
+	other, ok := o.(TaintsType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t TaintsType) String() string {
+	return "TaintsType"
+}
+
+func (t TaintsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributes := in.Attributes()
+
+	effectAttribute, ok := attributes["effect"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`effect is missing from object`)
+
+		return nil, diags
+	}
+
+	effectVal, ok := effectAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`effect expected to be basetypes.StringValue, was: %T`, effectAttribute))
+	}
+
+	keyAttribute, ok := attributes["key"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`key is missing from object`)
+
+		return nil, diags
+	}
+
+	keyVal, ok := keyAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`key expected to be basetypes.StringValue, was: %T`, keyAttribute))
+	}
+
+	valueAttribute, ok := attributes["value"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`value is missing from object`)
+
+		return nil, diags
+	}
+
+	valueVal, ok := valueAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`value expected to be basetypes.StringValue, was: %T`, valueAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return TaintsValue{
+		Effect: effectVal,
+		Key:    keyVal,
+		Value:  valueVal,
+		state:  attr.ValueStateKnown,
+	}, diags
+}
+
+func NewTaintsValueNull() TaintsValue {
+	return TaintsValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewTaintsValueUnknown() TaintsValue {
+	return TaintsValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewTaintsValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (TaintsValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing TaintsValue Attribute Value",
+				"While creating a TaintsValue value, a missing attribute value was detected. "+
+					"A TaintsValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("TaintsValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid TaintsValue Attribute Type",
+				"While creating a TaintsValue value, an invalid attribute value was detected. "+
+					"A TaintsValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("TaintsValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("TaintsValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra TaintsValue Attribute Value",
+				"While creating a TaintsValue value, an extra attribute value was detected. "+
+					"A TaintsValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra TaintsValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewTaintsValueUnknown(), diags
+	}
+
+	effectAttribute, ok := attributes["effect"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`effect is missing from object`)
+
+		return NewTaintsValueUnknown(), diags
+	}
+
+	effectVal, ok := effectAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`effect expected to be basetypes.StringValue, was: %T`, effectAttribute))
+	}
+
+	keyAttribute, ok := attributes["key"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`key is missing from object`)
+
+		return NewTaintsValueUnknown(), diags
+	}
+
+	keyVal, ok := keyAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`key expected to be basetypes.StringValue, was: %T`, keyAttribute))
+	}
+
+	valueAttribute, ok := attributes["value"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`value is missing from object`)
+
+		return NewTaintsValueUnknown(), diags
+	}
+
+	valueVal, ok := valueAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`value expected to be basetypes.StringValue, was: %T`, valueAttribute))
+	}
+
+	if diags.HasError() {
+		return NewTaintsValueUnknown(), diags
+	}
+
+	return TaintsValue{
+		Effect: effectVal,
+		Key:    keyVal,
+		Value:  valueVal,
+		state:  attr.ValueStateKnown,
+	}, diags
+}
+
+func NewTaintsValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) TaintsValue {
+	object, diags := NewTaintsValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewTaintsValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t TaintsType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewTaintsValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewTaintsValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewTaintsValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewTaintsValueMust(TaintsValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t TaintsType) ValueType(ctx context.Context) attr.Value {
+	return TaintsValue{}
+}
+
+var _ basetypes.ObjectValuable = TaintsValue{}
+
+type TaintsValue struct {
+	Effect basetypes.StringValue `tfsdk:"effect"`
+	Key    basetypes.StringValue `tfsdk:"key"`
+	Value  basetypes.StringValue `tfsdk:"value"`
+	state  attr.ValueState
+}
+
+func (v TaintsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 3)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["effect"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["key"] = basetypes.StringType{}.TerraformType(ctx)
+	attrTypes["value"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 3)
+
+		val, err = v.Effect.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["effect"] = val
+
+		val, err = v.Key.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["key"] = val
+
+		val, err = v.Value.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["value"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v TaintsValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v TaintsValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v TaintsValue) String() string {
+	return "TaintsValue"
+}
+
+func (v TaintsValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	objVal, diags := types.ObjectValue(
+		map[string]attr.Type{
+			"effect": basetypes.StringType{},
+			"key":    basetypes.StringType{},
+			"value":  basetypes.StringType{},
+		},
+		map[string]attr.Value{
+			"effect": v.Effect,
+			"key":    v.Key,
+			"value":  v.Value,
+		})
+
+	return objVal, diags
+}
+
+func (v TaintsValue) Equal(o attr.Value) bool {
+	other, ok := o.(TaintsValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.Effect.Equal(other.Effect) {
+		return false
+	}
+
+	if !v.Key.Equal(other.Key) {
+		return false
+	}
+
+	if !v.Value.Equal(other.Value) {
+		return false
+	}
+
+	return true
+}
+
+func (v TaintsValue) Type(ctx context.Context) attr.Type {
+	return TaintsType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v TaintsValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"effect": basetypes.StringType{},
+		"key":    basetypes.StringType{},
+		"value":  basetypes.StringType{},
+	}
 }

--- a/internal/provider/spotnodepool_resource.go
+++ b/internal/provider/spotnodepool_resource.go
@@ -276,6 +276,9 @@ func (r *spotnodepoolResource) Update(ctx context.Context, req resource.UpdateRe
 	}
 
 	// Get the latest version of the resource before we update it
+	// We need to get the latest version to ensure we have the most up-to-date resource version
+	// This is required for Kubernetes concurrency control, even though Terraform does its own refresh
+	// because other controllers may have modified the resource between our read and update
 	tflog.Debug(ctx, "Getting latest version of spotnodepool", map[string]any{"name": name})
 	latest := &ngpcv1.SpotNodePool{}
 	err = r.ngpcClient.Get(ctx, ktypes.NamespacedName{Name: name, Namespace: namespace}, latest)

--- a/provider_code_spec.json
+++ b/provider_code_spec.json
@@ -636,6 +636,70 @@
 						}
 					},
 					{
+						"name": "labels",
+						"map": {
+							"computed_optional_required": "optional",
+							"description": "Labels to be applied to the nodes of the node pool",
+							"element_type": {
+								"string": {}
+							}
+						}
+					},
+					{
+						"name": "annotations",
+						"map": {
+							"computed_optional_required": "optional",
+							"description": "Annotations to be applied to the nodes of the node pool",
+							"element_type": {
+								"string": {}
+							}
+						}
+					},
+					{
+						"name": "taints",
+						"list_nested": {
+							"computed_optional_required": "optional",
+							"description": "Kubernetes taints to be applied to the nodes of the node pool",
+							"nested_object": {
+								"attributes": [
+									{
+										"name": "key",
+										"string": {
+											"computed_optional_required": "required",
+											"description": "The taint key to be applied"
+										}
+									},
+									{
+										"name": "value",
+										"string": {
+											"computed_optional_required": "optional",
+											"description": "The taint value"
+										}
+									},
+									{
+										"name": "effect",
+										"string": {
+											"computed_optional_required": "required",
+											"description": "The taint effect (NoSchedule, PreferNoSchedule, or NoExecute)",
+											"validators": [
+												{
+													"custom": {
+														"imports": [
+															{
+																"path": "github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+															}
+														],
+														"schema_definition": "stringvalidator.OneOf(\"NoSchedule\", \"PreferNoSchedule\", \"NoExecute\")"
+													}
+												}
+											]
+										}
+									}
+								]
+							}
+						}
+					},
+					{
 						"name": "autoscaling",
 						"single_nested": {
 							"computed_optional_required": "optional",
@@ -905,6 +969,70 @@
 								}
 							],
 							"description": "Number of reserved on-demand nodes."
+						}
+					},
+					{
+						"name": "labels",
+						"map": {
+							"computed_optional_required": "optional",
+							"description": "Labels to be applied to the nodes of the node pool",
+							"element_type": {
+								"string": {}
+							}
+						}
+					},
+					{
+						"name": "annotations",
+						"map": {
+							"computed_optional_required": "optional",
+							"description": "Annotations to be applied to the nodes of the node pool",
+							"element_type": {
+								"string": {}
+							}
+						}
+					},
+					{
+						"name": "taints",
+						"list_nested": {
+							"computed_optional_required": "optional",
+							"description": "Kubernetes taints to be applied to the nodes of the node pool",
+							"nested_object": {
+								"attributes": [
+									{
+										"name": "key",
+										"string": {
+											"computed_optional_required": "required",
+											"description": "The taint key to be applied"
+										}
+									},
+									{
+										"name": "value",
+										"string": {
+											"computed_optional_required": "optional",
+											"description": "The taint value"
+										}
+									},
+									{
+										"name": "effect",
+										"string": {
+											"computed_optional_required": "required",
+											"description": "The taint effect (NoSchedule, PreferNoSchedule, or NoExecute)",
+											"validators": [
+												{
+													"custom": {
+														"imports": [
+															{
+																"path": "github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+															}
+														],
+														"schema_definition": "stringvalidator.OneOf(\"NoSchedule\", \"PreferNoSchedule\", \"NoExecute\")"
+													}
+												}
+											]
+										}
+									}
+								]
+							}
 						}
 					}
 				]
@@ -1254,6 +1382,70 @@
 						"int64": {
 							"computed_optional_required": "computed",
 							"description": "Number of won bids."
+						}
+					},
+					{
+						"name": "labels",
+						"map": {
+							"computed_optional_required": "optional",
+							"description": "Labels to be applied to the nodes of the node pool",
+							"element_type": {
+								"string": {}
+							}
+						}
+					},
+					{
+						"name": "annotations",
+						"map": {
+							"computed_optional_required": "optional",
+							"description": "Annotations to be applied to the nodes of the node pool",
+							"element_type": {
+								"string": {}
+							}
+						}
+					},
+					{
+						"name": "taints",
+						"list_nested": {
+							"computed_optional_required": "optional",
+							"description": "Kubernetes taints to be applied to the nodes of the node pool",
+							"nested_object": {
+								"attributes": [
+									{
+										"name": "key",
+										"string": {
+											"computed_optional_required": "required",
+											"description": "The taint key to be applied"
+										}
+									},
+									{
+										"name": "value",
+										"string": {
+											"computed_optional_required": "optional",
+											"description": "The taint value"
+										}
+									},
+									{
+										"name": "effect",
+										"string": {
+											"computed_optional_required": "required",
+											"description": "The taint effect (NoSchedule, PreferNoSchedule, or NoExecute)",
+											"validators": [
+												{
+													"custom": {
+														"imports": [
+															{
+																"path": "github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+															}
+														],
+														"schema_definition": "stringvalidator.OneOf(\"NoSchedule\", \"PreferNoSchedule\", \"NoExecute\")"
+													}
+												}
+											]
+										}
+									}
+								]
+							}
 						}
 					}
 				]
@@ -1811,6 +2003,70 @@
 						"int64": {
 							"computed_optional_required": "computed",
 							"description": "Number of reserved on-demand nodes."
+						}
+					},
+					{
+						"name": "labels",
+						"map": {
+							"computed_optional_required": "optional",
+							"description": "Labels to be applied to the nodes of the node pool",
+							"element_type": {
+								"string": {}
+							}
+						}
+					},
+					{
+						"name": "annotations",
+						"map": {
+							"computed_optional_required": "optional",
+							"description": "Annotations to be applied to the nodes of the node pool",
+							"element_type": {
+								"string": {}
+							}
+						}
+					},
+					{
+						"name": "taints",
+						"list_nested": {
+							"computed_optional_required": "optional",
+							"description": "Kubernetes taints to be applied to the nodes of the node pool",
+							"nested_object": {
+								"attributes": [
+									{
+										"name": "key",
+										"string": {
+											"computed_optional_required": "required",
+											"description": "The taint key to be applied"
+										}
+									},
+									{
+										"name": "value",
+										"string": {
+											"computed_optional_required": "optional",
+											"description": "The taint value"
+										}
+									},
+									{
+										"name": "effect",
+										"string": {
+											"computed_optional_required": "required",
+											"description": "The taint effect (NoSchedule, PreferNoSchedule, or NoExecute)",
+											"validators": [
+												{
+													"custom": {
+														"imports": [
+															{
+																"path": "github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+															}
+														],
+														"schema_definition": "stringvalidator.OneOf(\"NoSchedule\", \"PreferNoSchedule\", \"NoExecute\")"
+													}
+												}
+											]
+										}
+									}
+								]
+							}
 						}
 					}
 				]


### PR DESCRIPTION
Allow specifying custom labels, annotations, and taints to nodepools

Example:
```
resource "spot_spotnodepool" "autoscaling-bid" {
  cloudspace_name = resource.spot_cloudspace.example.cloudspace_name
  server_class    = "gp.vs1.medium-dfw"
  bid_price       = 0.012

  autoscaling = {
    min_nodes = 1
    max_nodes = 2
  }

  labels = {
    "environment" = "production"
    "team" = "backend"
  }

  annotations = {
    "example.com/description"   = "Autoscaling spot pool"
  }

  taints = [
    {
      key    = "workload"
      value  = "critical"
      effect = "NoSchedule"
    }
  ]

}
```