### PR TITLE
fix: Update oapi-codegen and terraform-plugin-docs dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,8 @@ scaffold-provider:
 
 dependencies:
 	@echo "Installing dependencies..."
-	go install github.com/deepmap/oapi-codegen/v2/cmd/oapi-codegen@latest
+	go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@latest
+	go install github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
 
 check-versions:
 	@echo "Checking Go version..."


### PR DESCRIPTION
The `dependencies` target in the Makefile helps developers install required tools. It has been improved by adding `tfplugindocs`, as explained [here](https://github.com/hashicorp/terraform-plugin-docs?tab=readme-ov-file#installation).